### PR TITLE
[16.0][account_banking_pain_base] bugfix _improved_street_split when partner address is only a dot or a comma

### DIFF
--- a/account_banking_pain_base/models/res_partner.py
+++ b/account_banking_pain_base/models/res_partner.py
@@ -99,11 +99,9 @@ class ResPartner(models.Model):
     def _improved_street_split(self, street):
         # This method is fully tested in tests/test_pain.py
         logger.debug("_improved_street_split called on '%s'", street)
-        street = street and street.strip()
+        street = street and street.strip().replace(",", " ").replace(".", " ")
         if not street:
             return (False, False)
-        street = street.replace(",", " ")
-        street = street.replace(".", " ")
         # replace all multi-spaces by one space
         street = " ".join(street.split())
 


### PR DESCRIPTION
If partner's address is only a dot "." or a comma ",", `_improved_street_split` fails with following error:

RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/home/odoo/o16/odoo/http.py", line 1651, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/o16/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/o16/odoo/http.py", line 1678, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/o16/odoo/http.py", line 1882, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/o16/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/o16/odoo/http.py", line 732, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/o16/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/o16/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/o16/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/o16/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/o16/addons-oca/bank-payment/account_payment_order/models/account_payment_order.py", line 443, in open2generated
    payment_file_bytes, filename = self.generate_payment_file()
  File "/home/odoo/o16/addons-oca/bank-payment/account_banking_sepa_credit_transfer/models/account_payment_order.py", line 131, in generate_payment_file
    self._generate_party_block(
  File "/home/odoo/o16/addons-oca/bank-payment/account_banking_pain_base/models/account_payment_order.py", line 484, in _generate_party_block
    partner._generate_address_block(party, gen_args)
  File "/home/odoo/o16/addons-oca/bank-payment/account_banking_pain_base/models/res_partner.py", line 55, in _generate_address_block
    street_name, street_number = self._improved_street_split(
  File "/home/odoo/o16/addons-oca/bank-payment/account_banking_pain_base/models/res_partner.py", line 131, in _improved_street_split
    if street_split[0][0].isdigit():
IndexError: string index out of range

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (https://erp.aluval.fr/web/assets/15109-6f62756/web.assets_backend.min.js:1001:163)
        at XMLHttpRequest.<anonymous> (https://erp.aluval.fr/web/assets/15109-6f62756/web.assets_backend.min.js:1009:13)